### PR TITLE
doc and blog `edit page` links to repo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,13 +28,13 @@ const config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: 'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+          editUrl: 'https://github.com/techconative/restel-docs/blob/main/',
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/techconative/restel-docs/blob/main/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
#1 
Edit this page link points to corresponding files within restel-doc.